### PR TITLE
only do auto, no validation

### DIFF
--- a/rio_stac/scripts/cli.py
+++ b/rio_stac/scripts/cli.py
@@ -3,6 +3,7 @@ import datetime
 import json
 
 import click
+from pystac import MediaType
 from pystac.utils import datetime_to_str, str_to_datetime
 from rasterio.rio import options
 
@@ -56,6 +57,11 @@ def _cb_key_val(ctx, param, value):
 @click.option("--id", type=str, help="Item id.")
 @click.option("--asset-name", "-n", type=str, default="cog", help="Asset name.")
 @click.option("--asset-href", type=str, default="asset", help="Overwrite asset href.")
+@click.option(
+    "--asset-mediatype",
+    type=click.Choice([it.name for it in MediaType] + ["auto"]),
+    help="Asset media-type (e.g `image/tiff; application=geotiff; profile=cloud-optimized'`).",
+)
 @click.option("--output", "-o", type=click.Path(exists=False), help="Output file name")
 def stac(
     input,
@@ -66,6 +72,7 @@ def stac(
     id,
     asset_name,
     asset_href,
+    asset_mediatype,
     output,
 ):
     """Rasterio stac cli."""
@@ -82,6 +89,9 @@ def stac(
             property["end_datetime"] = datetime_to_str(str_to_datetime(end_datetime))
             input_datetime = None
 
+    if asset_mediatype and asset_mediatype != "auto":
+        asset_mediatype = MediaType[asset_mediatype]
+
     item = create_stac_item(
         input,
         input_datetime=input_datetime,
@@ -91,6 +101,7 @@ def stac(
         id=id,
         asset_name=asset_name,
         asset_href=asset_href,
+        asset_media_type=asset_mediatype,
     )
 
     if output:

--- a/rio_stac/stac.py
+++ b/rio_stac/stac.py
@@ -75,18 +75,16 @@ def get_metadata(
 
 
 def get_media_type(
-    src_dst: Union[DatasetReader, DatasetWriter, WarpedVRT, MemoryFile],
-    input_media_type: Optional[pystac.MediaType] = None,
+    src_dst: Union[DatasetReader, DatasetWriter, WarpedVRT, MemoryFile]
 ) -> Optional[pystac.MediaType]:
     """Define or validate MediaType."""
     driver = src_dst.driver
 
-    output_media_type = input_media_type
     if driver == "GTiff":
         if src_dst.crs:
-            output_media_type = pystac.MediaType.GEOTIFF
+            return pystac.MediaType.GEOTIFF
         else:
-            output_media_type = pystac.MediaType.TIFF
+            return pystac.MediaType.TIFF
 
     elif driver in [
         "JP2ECW",
@@ -96,31 +94,22 @@ def get_media_type(
         "JP2OpenJPEG",
         "JPEG2000",
     ]:
-        output_media_type = pystac.MediaType.JPEG2000
+        return pystac.MediaType.JPEG2000
 
     elif driver in ["HDF4", "HDF4Image"]:
-        output_media_type = pystac.MediaType.HDF
+        return pystac.MediaType.HDF
 
     elif driver in ["HDF5", "HDF5Image"]:
-        output_media_type = pystac.MediaType.HDF5
+        return pystac.MediaType.HDF5
 
     elif driver == "JPEG":
-        output_media_type = pystac.MediaType.JPEG
+        return pystac.MediaType.JPEG
 
     elif driver == "PNG":
-        output_media_type = pystac.MediaType.PNG
+        return pystac.MediaType.PNG
 
-    if not output_media_type:
-        warnings.warn("Could not determine the media type from GDAL driver.")
-        return input_media_type
-
-    if input_media_type == pystac.MediaType.COG and driver != "GTiff":
-        raise Exception("Input file is not a GeoTIFF.")
-
-    elif input_media_type and output_media_type != input_media_type:
-        raise Exception("MediaType do not match.")
-
-    return output_media_type
+    warnings.warn("Could not determine the media type from GDAL driver.")
+    return None
 
 
 def create_stac_item(
@@ -132,7 +121,7 @@ def create_stac_item(
     id: Optional[str] = None,
     asset_name: str = "asset",
     asset_roles: Optional[List[str]] = None,
-    asset_media_type: Optional[pystac.MediaType] = None,
+    asset_media_type: Optional[Union[str, pystac.MediaType]] = "auto",
     asset_href: Optional[str] = None,
 ) -> pystac.Item:
     """Create a Stac Item.
@@ -146,7 +135,7 @@ def create_stac_item(
         id (str, optional): id to assign to the item (default to the source basename).
         asset_name (str, optional): asset name in the Assets object.
         asset_roles (list of str, optional): list of asset's role.
-        asset_media_type (pystac.MediaType, optional): asset's media type (default to COG).
+        asset_media_type (str or pystac.MediaType, optional): asset's media type.
         asset_href (str, optional): asset's URI (default to input path).
 
     Returns:
@@ -160,7 +149,10 @@ def create_stac_item(
             src_dst = ctx.enter_context(rasterio.open(source))
 
         meta = get_metadata(src_dst)
-        asset_media_type = get_media_type(src_dst, input_media_type=asset_media_type)
+
+        media_type = (
+            get_media_type(src_dst) if asset_media_type == "auto" else asset_media_type
+        )
 
     properties = item_properties or {}
 
@@ -189,9 +181,7 @@ def create_stac_item(
     # item.assets
     item.add_asset(
         key=asset_name,
-        asset=pystac.Asset(
-            href=asset_href or meta["name"], media_type=asset_media_type,
-        ),
+        asset=pystac.Asset(href=asset_href or meta["name"], media_type=media_type,),
     )
 
     return item.to_dict()

--- a/tests/test_mediatype.py
+++ b/tests/test_mediatype.py
@@ -54,19 +54,3 @@ def test_unknow():
     with rasterio.open(src_path) as src_dst:
         with pytest.warns(UserWarning):
             assert not get_media_type(src_dst)
-
-
-@pytest.mark.parametrize(
-    "file,mediatype",
-    [
-        ["dataset.jpg", pystac.MediaType.COG],
-        ["dataset_cog.tif", pystac.MediaType.TIFF],
-        ["dataset.tif", pystac.MediaType.GEOTIFF],
-        ["dataset.jpg", pystac.MediaType.PNG],
-    ],
-)
-def test_invalid_input(file, mediatype):
-    src_path = os.path.join(PREFIX, file)
-    with rasterio.open(src_path) as src_dst:
-        with pytest.raises(Exception):
-            get_media_type(src_dst, mediatype)


### PR DESCRIPTION
This PR does:

- remove validation of media type
- add `auto` to tell the API to find the media type

Validation is a bit tricky and I think doing either `auto` or `nothing` is just simpler

cc @kylebarron 