### PR TITLE
update pystac and add item validation in CI

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,16 @@
 
+## 0.2.0 (TBD)
+
+* fix validation issue with Collection and extension for STAC 1.0.0
+* add collection_url option to customize the collection link
+
+**breaking changes**
+
+* update pystac version to `>=1.0.0rc1`
+* use full URL for extension
+* add Collection Link when adding a collection
+* add with_proj (--with-proj/--without-proj in the CLI) in `create_stac_item` to add the extension and proj properties in the stac items (will do the same for the raster extension)
+
 ## 0.1.1 (2021-03-19)
 
 * fix CLI asset-href default

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -10,17 +10,19 @@ $ rio stac --help
 
 Usage: rio stac [OPTIONS] INPUT
 
-  Rasterio stac cli.
+  Rasterio STAC plugin: Create a STAC Item for raster dataset.
 
 Options:
   -d, --datetime TEXT             The date and time of the assets, in UTC (e.g 2020-01-01, 2020-01-01T01:01:01).
-  -e, --extension TEXT            STAC extensions the Item implements (default is set to ["proj"]). Multiple allowed (e.g. `-e extension1 -e extensio2`).
+  -e, --extension TEXT            STAC extensions the Item implements (default is set to ["proj"]). Multiple allowed (e.g. `-e extensionUrl1 -e extensionUrl2`).
   -c, --collection TEXT           The Collection ID that this item belongs to.
+  --collection-url TEXT           Link to the STAC Collection.
   -p, --property NAME=VALUE       Additional property to add (e.g `-p myprops=1`). Multiple allowed.
   --id TEXT                       Item id.
   -n, --asset-name TEXT           Asset name.
   --asset-href TEXT               Overwrite asset href.
   --asset-mediatype [COG|GEOJSON|GEOPACKAGE|GEOTIFF|HDF|HDF5|JPEG|JPEG2000|JSON|PNG|TEXT|TIFF|XML|auto] Asset media-type.
+  --with-proj / --without-proj    Add the projection extension and properties (default to True).
   -o, --output PATH               Output file name
   --help                          Show this message and exit.
 ```
@@ -39,7 +41,11 @@ The CLI can be run as is, just by passing a `source` raster data. You can also u
 
     STAC Item can have [extensions](https://github.com/radiantearth/stac-spec/tree/master/extensions) which indicates that the item has additional properies (e.g proj information). This option can be set multiple times.
 
-    By default the `proj` extension will be added to the item.
+    You can pass the extension option multiple times: `-e extension1 -e extension2`.
+
+- **projection extension** (--with-proj / --without-proj)
+
+    By default the `projection` extension and properties will be added to the item:
     ```
     {
         "proj:epsg": 3857,
@@ -51,19 +57,15 @@ The CLI can be run as is, just by passing a `source` raster data. You can also u
     }
     ```
 
-    You can overwrite the default by setting your own list of extensions (e.g `-e extension1 -e extension2`).
-
-    ¡¡¡ important !!!
-
-    To exclude any extension you MUST set: `--extension ""`
-
-    If you want to add extension and still have the `proj` extension enabled, you MUST add it back: `--extension myext --extension proj`
+    You can pass `--without-proj` to disable it.
 
 - **collection** (-c, --collection)
 
     Add a `collection` attribute to the item.
 
-    Note: This won't add the collection's `link`.
+- **collection link** (--collection-url)
+
+    When adding a collection to the Item, the specification state that a Link must also be set. By default the `href` will be set with the collection id. You can specify a custom URL using this option.
 
 - **properties** (-p, --property)
 

--- a/rio_stac/scripts/cli.py
+++ b/rio_stac/scripts/cli.py
@@ -40,7 +40,6 @@ def _cb_key_val(ctx, param, value):
     "--extension",
     "-e",
     type=str,
-    default=["https://stac-extensions.github.io/projection/v1.0.0/schema.json"],
     multiple=True,
     help="STAC extension URL the Item implements.",
 )
@@ -63,6 +62,11 @@ def _cb_key_val(ctx, param, value):
     type=click.Choice([it.name for it in MediaType] + ["auto"]),
     help="Asset media-type.",
 )
+@click.option(
+    "--with-proj/--without-proj",
+    default=True,
+    help="Add the projection extension and the projection properties.",
+)
 @click.option("--output", "-o", type=click.Path(exists=False), help="Output file name")
 def stac(
     input,
@@ -74,6 +78,7 @@ def stac(
     asset_name,
     asset_href,
     asset_mediatype,
+    with_proj,
     output,
 ):
     """Rasterio stac cli."""
@@ -107,6 +112,7 @@ def stac(
         asset_name=asset_name,
         asset_href=asset_href,
         asset_media_type=asset_mediatype,
+        with_proj=with_proj,
     )
 
     if output:

--- a/rio_stac/scripts/cli.py
+++ b/rio_stac/scripts/cli.py
@@ -46,6 +46,7 @@ def _cb_key_val(ctx, param, value):
 @click.option(
     "--collection", "-c", type=str, help="The Collection ID that this item belongs to."
 )
+@click.option("--collection-url", type=str, help="Link to the STAC Collection.")
 @click.option(
     "--property",
     "-p",
@@ -65,7 +66,7 @@ def _cb_key_val(ctx, param, value):
 @click.option(
     "--with-proj/--without-proj",
     default=True,
-    help="Add the projection extension and the projection properties.",
+    help="Add the projection extension and properties (default to True).",
 )
 @click.option("--output", "-o", type=click.Path(exists=False), help="Output file name")
 def stac(
@@ -73,6 +74,7 @@ def stac(
     input_datetime,
     extension,
     collection,
+    collection_url,
     property,
     id,
     asset_name,
@@ -81,7 +83,7 @@ def stac(
     with_proj,
     output,
 ):
-    """Rasterio stac cli."""
+    """Rasterio STAC plugin: Create a STAC Item for raster dataset."""
     property = property or {}
 
     if not input_datetime:
@@ -107,6 +109,7 @@ def stac(
         input_datetime=input_datetime,
         extensions=extensions,
         collection=collection,
+        collection_url=collection_url,
         properties=property,
         id=id,
         asset_name=asset_name,

--- a/rio_stac/scripts/cli.py
+++ b/rio_stac/scripts/cli.py
@@ -40,9 +40,9 @@ def _cb_key_val(ctx, param, value):
     "--extension",
     "-e",
     type=str,
-    default=["proj"],
+    default=["https://stac-extensions.github.io/projection/v1.0.0/schema.json"],
     multiple=True,
-    help="STAC extension the Item implements.",
+    help="STAC extension URL the Item implements.",
 )
 @click.option(
     "--collection", "-c", type=str, help="The Collection ID that this item belongs to."

--- a/rio_stac/stac.py
+++ b/rio_stac/stac.py
@@ -144,7 +144,7 @@ def create_stac_item(
         asset_roles (list of str, optional): list of asset's role.
         asset_media_type (str or pystac.MediaType, optional): asset's media type.
         asset_href (str, optional): asset's URI (default to input path).
-        with_proj (bool): Add the projection extension and properties.
+        with_proj (bool): Add the projection extension and properties (default to False).
 
     Returns:
         pystac.Item: valid STAC Item.
@@ -166,6 +166,7 @@ def create_stac_item(
 
     extensions = extensions or []
 
+    # add projection properties
     if with_proj:
         properties.update(
             {
@@ -189,6 +190,7 @@ def create_stac_item(
         properties=properties,
     )
 
+    # if we add a collection we MUST add a link
     if collection:
         item.add_link(
             pystac.Link(

--- a/setup.py
+++ b/setup.py
@@ -7,12 +7,12 @@ with open("README.md") as f:
 
 inst_reqs = [
     "rasterio",
-    "pystac>=0.5,<0.6",
+    "pystac>=1.0.0rc1,<1.0.1",
 ]
 
 extra_reqs = {
-    "dev": ["pytest", "pytest-cov", "pre-commit", "requests"],
-    "test": ["pytest", "pytest-cov", "requests"],
+    "dev": ["pytest", "pytest-cov", "pre-commit", "requests", "jsonschema>=3.0"],
+    "test": ["pytest", "pytest-cov", "requests", "jsonschema>=3.0"],
     "docs": ["mkdocs", "mkdocs-material", "pygments", "pdocs"],
 }
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -30,7 +30,7 @@ def test_rio_stac_cli(runner):
 
         result = runner.invoke(
             stac,
-            [src_path, "--extension", "", "--datetime", "2010-01-01", "--id", "000001"],
+            [src_path, "--without-proj", "--datetime", "2010-01-01", "--id", "000001"],
         )
         assert not result.exception
         assert result.exit_code == 0
@@ -41,7 +41,7 @@ def test_rio_stac_cli(runner):
         assert stac_item["properties"]["datetime"] == "2010-01-01T00:00:00Z"
 
         result = runner.invoke(
-            stac, [src_path, "--extension", "", "--datetime", "2010-01-01/2010-01-02"]
+            stac, [src_path, "--without-proj", "--datetime", "2010-01-01/2010-01-02"]
         )
         assert not result.exception
         assert result.exit_code == 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -22,7 +22,9 @@ def test_rio_stac_cli(runner):
         assert stac_item["assets"]["asset"]
         assert stac_item["assets"]["asset"]["href"] == src_path
         assert stac_item["links"] == []
-        assert stac_item["stac_extensions"] == ["proj"]
+        assert stac_item["stac_extensions"] == [
+            "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
+        ]
         assert "datetime" in stac_item["properties"]
         assert "proj:epsg" in stac_item["properties"]
 
@@ -80,6 +82,8 @@ def test_rio_stac_cli(runner):
         assert stac_item["type"] == "Feature"
         assert stac_item["assets"]["asset"]
         assert stac_item["links"] == []
-        assert stac_item["stac_extensions"] == ["proj"]
+        assert stac_item["stac_extensions"] == [
+            "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
+        ]
         assert "datetime" in stac_item["properties"]
         assert "proj:epsg" in stac_item["properties"]

--- a/tests/test_create_item.py
+++ b/tests/test_create_item.py
@@ -60,7 +60,10 @@ def test_create_item_options():
 
     # default COG
     item = create_stac_item(
-        src_path, input_datetime=input_date, asset_media_type=pystac.MediaType.COG,
+        src_path,
+        input_datetime=input_date,
+        asset_media_type=pystac.MediaType.COG,
+        with_proj=False,
     )
     assert item.validate()
     item_dict = item.to_dict()
@@ -73,19 +76,36 @@ def test_create_item_options():
     item = create_stac_item(
         src_path,
         input_datetime=input_date,
-        extensions=[
-            "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
-            "https://stac-extensions.github.io/scientific/v1.0.0/schema.json",
-        ],
+        extensions=["https://stac-extensions.github.io/scientific/v1.0.0/schema.json"],
         properties={"sci:citation": "A nice image"},
+        with_proj=False,
     )
     assert item.validate()
     item_dict = item.to_dict()
     assert "type" not in item_dict["assets"]["asset"]
     assert item_dict["links"] == []
     assert item_dict["stac_extensions"] == [
-        "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
         "https://stac-extensions.github.io/scientific/v1.0.0/schema.json",
+    ]
+    assert "datetime" in item_dict["properties"]
+    assert "proj:epsg" not in item_dict["properties"]
+    assert "sci:citation" in item_dict["properties"]
+
+    # additional extensions and properties
+    item = create_stac_item(
+        src_path,
+        input_datetime=input_date,
+        extensions=["https://stac-extensions.github.io/scientific/v1.0.0/schema.json"],
+        properties={"sci:citation": "A nice image"},
+        with_proj=True,
+    )
+    assert item.validate()
+    item_dict = item.to_dict()
+    assert "type" not in item_dict["assets"]["asset"]
+    assert item_dict["links"] == []
+    assert item_dict["stac_extensions"] == [
+        "https://stac-extensions.github.io/scientific/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
     ]
     assert "datetime" in item_dict["properties"]
     assert "proj:epsg" in item_dict["properties"]
@@ -93,7 +113,9 @@ def test_create_item_options():
 
     # external assets
     assets = {"cog": pystac.Asset(href=src_path)}
-    item = create_stac_item(src_path, input_datetime=input_date, assets=assets)
+    item = create_stac_item(
+        src_path, input_datetime=input_date, assets=assets, with_proj=False
+    )
     assert item.validate()
     item_dict = item.to_dict()
     assert item_dict["assets"]["cog"]
@@ -103,7 +125,7 @@ def test_create_item_options():
 
     # collection
     item = create_stac_item(
-        src_path, input_datetime=input_date, collection="mycollection",
+        src_path, input_datetime=input_date, collection="mycollection", with_proj=False
     )
     assert item.validate()
     item_dict = item.to_dict()
@@ -117,6 +139,7 @@ def test_create_item_options():
         input_datetime=input_date,
         collection="mycollection",
         collection_url="https://stac.somewhere.io/mycollection.json",
+        with_proj=False,
     )
     assert item.validate()
     item_dict = item.to_dict()


### PR DESCRIPTION
ref #9 

This PR does:
- adapt for pystac 1.0.0rc
- add item validation in CI (This should have been in previous version 🤦)
- fix validation issue with Collection and extension
- use full URL for extension
- add Collection Link when adding a collection
- add `collection_url` option to customize the collection link

## breaking changes

- add `with_proj` (`--with-proj/--without-proj` in the CLI) in `create_stac_item` to add the extension and proj properties in the stac items (will do the same for the raster extension)
