### PR TITLE
Allow pystac 1.1.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.0
+current_version = 0.3.1
 commit = True
 tag = True
 tag_name = {new_version}

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md") as f:
 
 inst_reqs = [
     "rasterio",
-    "pystac>=1.0.0,<1.1.0",
+    "pystac>=1.0.0",
 ]
 
 extra_reqs = {


### PR DESCRIPTION
Simple as this, allow PySTAC 1.1.0. There are no significant differences between 1.0.0 and 1.1.0, as far as I know, and we're having build dependency problems because of this constraint.