### PR TITLE
set default geom_precision to -1

### DIFF
--- a/rio_stac/scripts/cli.py
+++ b/rio_stac/scripts/cli.py
@@ -103,6 +103,7 @@ def _cb_key_val(ctx, param, value):
 @click.option(
     "--geom-precision",
     type=int,
+    default=-1,
     help="Round geometry coordinates to this number of decimal.",
 )
 @click.option("--output", "-o", type=click.Path(exists=False), help="Output file name")
@@ -137,7 +138,6 @@ def stac(
     """Rasterio STAC plugin: Create a STAC Item for raster dataset."""
     property = property or {}
     densify_geom = densify_geom or 0
-    geom_precision = geom_precision or 0
 
     if input_datetime:
         if "/" in input_datetime:

--- a/rio_stac/stac.py
+++ b/rio_stac/stac.py
@@ -42,7 +42,7 @@ def bbox_to_geom(bbox: Tuple[float, float, float, float]) -> Dict:
 def get_dataset_geom(
     src_dst: Union[DatasetReader, DatasetWriter, WarpedVRT, MemoryFile],
     densify_pts: int = 0,
-    precision: int = 0,
+    precision: int = -1,
 ) -> Dict:
     """Get Raster Footprint."""
     if densify_pts < 0:
@@ -281,7 +281,7 @@ def create_stac_item(
     with_eo: bool = False,
     raster_max_size: int = 1024,
     geom_densify_pts: int = 0,
-    geom_precision: int = 0,
+    geom_precision: int = -1,
 ) -> pystac.Item:
     """Create a Stac Item.
 


### PR DESCRIPTION
This way `rio stac` will match the default behavior in `rasterio.warp.transform_geom`. Since the `bbox` and `geom` properties are always(?) `epsg:4326` rounding to zero decimal places is probably not what we want!

Resolves #49 