### PR TITLE
catch dateparsing issue

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,8 @@
 
+## 0.10.1 (2024-11-21)
+
+* catch date parsing issue and raise warning
+
 ## 0.10.0 (2024-10-29)
 
 * handle `TIFFTAG_DATETIME` metadata for STAC datetime

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 
 ## 0.10.1 (2024-11-21)
 
+* exclude rasterio version `1.4.2` from requirements
 * catch date parsing issue and raise warning
 
 ## 0.10.0 (2024-10-29)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-    "rasterio",
+    "rasterio>=1.0,!=1.4.2",
     "pystac>=1.0.0,<2.0.0",
 ]
 

--- a/rio_stac/stac.py
+++ b/rio_stac/stac.py
@@ -357,7 +357,12 @@ def create_stac_item(
             acq_date = src_dst.get_tag_item("ACQUISITIONDATETIME", "IMAGERY")
             tiff_date = src_dst.get_tag_item("TIFFTAG_DATETIME")
             dst_date = acq_date or tiff_date
-            dst_datetime = str_to_datetime(dst_date) if dst_date else None
+            try:
+                dst_datetime = str_to_datetime(dst_date) if dst_date else None
+            except ValueError as err:
+                warnings.warn(f"Could not get parse date: {dst_date}: {err}")
+                dst_datetime = None
+
             input_datetime = input_datetime or dst_datetime or datetime.datetime.utcnow()
 
         # add projection properties


### PR DESCRIPTION
```
AWS_REQUEST_PAYER=requester rio stac s3://naip-analytic/ny/2021/60cm/rgbir_cog/43075/m_4307562_ne_18_060_20220428.tif | jq

UserWarning: Could not get parse date: 2022:05:27 15:12:05: invalid literal for int() with base 10: b':05'
  warnings.warn(f"Could not get parse date: {dst_date}: {err}")
{
  "type": "Feature",
  "stac_version": "1.0.0",
  "id": "m_4307562_ne_18_060_20220428.tif",
  ...
```