### PR TITLE
Ensure valid_percent type is a python float

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,8 @@
 
+## 0.11.1 (2025-08-28)
+
+* avoid serialization issue for statistics
+
 ## 0.11.0 (2025-04-25)
 
 * Use timezone-aware objects to represent datetimes in UTC (avoid future deprecation)

--- a/rio_stac/stac.py
+++ b/rio_stac/stac.py
@@ -167,7 +167,9 @@ def _get_stats(arr: numpy.ma.MaskedArray, **kwargs: Any) -> Dict:
             "minimum": arr.min().item(),
             "maximum": arr.max().item(),
             "stddev": arr.std().item(),
-            "valid_percent": numpy.count_nonzero(~arr.mask) / float(arr.data.size) * 100,
+            "valid_percent": float(
+                numpy.count_nonzero(~arr.mask) / float(arr.data.size) * 100
+            ),
         },
         "histogram": {
             "count": len(edges),

--- a/tests/test_create_item.py
+++ b/tests/test_create_item.py
@@ -1,6 +1,7 @@
 """test media type functions."""
 
 import datetime
+import json
 import os
 
 import pystac
@@ -346,3 +347,12 @@ def test_mars_dataset():
         "proj:projjson" in item_dict["properties"]
         or "proj:wkt2" in item_dict["properties"]
     )
+
+
+def test_json_serialization():
+    """Test JSON serialization"""
+    src_path = os.path.join(PREFIX, "dataset_cog.tif")
+    item = create_stac_item(src_path, with_raster=True)
+    assert item.validate()
+    item_dict = item.to_dict()
+    assert json.dumps(item_dict)


### PR DESCRIPTION
The `valid_percent` property of the `statistics` in the `raster` extension is a `numpy.float64` type after doing `to_json()` on a stac item created through `create_stac_item`. This makes the dict not serializable.

I am running into a `TypeError: Type is not JSON serializable: numpy.float64` for the `valid_percent` when trying to serialize the `to_json()` output.

The proposed change should fix this by converting the numpy float to python float.